### PR TITLE
Updated .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,15 @@
 # Default ignored filereports
 /spikes/csv-structure-validation-function-app/target
 .vscode/
+
+# Build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+bld/
+[Bb]in/
+[Oo]bj/
+[Ll]og/


### PR DESCRIPTION
Updated .gitignore file to exclude .NET build artifacts. These artifacts were auto-generated when loading the repo root using VSCode when C# extensions were enabled.